### PR TITLE
[TAE-98] Save file size from event

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
@@ -57,7 +57,7 @@ public class BlobRegisterAdapter {
 
     fileMetadata.setName(cleanFilename(blobName));
 
-    fileMetadata.setLastTransitionTimestamp(eventTimeinLocal);
+    fileMetadata.setReceiveTimestamp(eventTimeinLocal);
 
     fileMetadata.setStatus(FileStatus.SUCCESS.getOrder());
 
@@ -65,7 +65,11 @@ public class BlobRegisterAdapter {
 
     fileMetadata.setApplication(evaluateApplication(fileType).getOrder());
 
-    fileMetadata.setReceiveTimestamp(eventTimeinLocal);
+    fileMetadata.setSize(extractFileSize(event));
+    if (fileMetadata.getSize() <= 0) {
+      log.warn("File size is "+ fileMetadata.getSize()+ " for event: " + event.getSubject());
+    }
+
     fileMetadataService.storeFileMetadata(fileMetadata);
 
     log.info("Evaluated event: {}", event.getSubject());

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.rtd.ms.rtdmsfileregister.adapter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.controller.RestController.FilenameAlreadyPresent;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.EventGridEvent;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileApplication;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataDTO;
@@ -49,6 +50,8 @@ public class BlobRegisterAdapter {
     if (fileType == FileType.UNKNOWN) {
       log.info(EVENT_NOT_OF_INTEREST_MSG + event.getSubject());
       return null;
+    } else {
+      log.info("Received event: " + event.getSubject());
     }
 
     String blobName = parts[6];
@@ -70,7 +73,11 @@ public class BlobRegisterAdapter {
       log.warn("File size is "+ fileMetadata.getSize()+ " for event: " + event.getSubject());
     }
 
-    fileMetadataService.storeFileMetadata(fileMetadata);
+    try {
+      fileMetadataService.storeFileMetadata(fileMetadata);
+    } catch (FilenameAlreadyPresent e){
+      log.warn("File already present: " + fileMetadata.getName());
+    }
 
     log.info("Evaluated event: {}", event.getSubject());
     return event;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
@@ -126,4 +126,19 @@ public class BlobRegisterAdapter {
     return FileApplication.UNKNOWN;
   }
 
+  public long extractFileSize(EventGridEvent event) {
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      JsonNode sizeNode = objectMapper.readTree(String.valueOf(event.getData()))
+          .get("contentLength");
+      if (sizeNode != null) {
+        return sizeNode.longValue();
+      } else {
+        log.warn("No contentLength in event: {}", event.getSubject());
+      }
+    } catch (JsonProcessingException e) {
+      log.warn("Failed to parse event: {}", event.getSubject());
+    }
+    return 0;
+  }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
@@ -109,27 +109,17 @@ public class BlobRegisterAdapter {
 
   public FileApplication evaluateApplication(FileType fileType) {
     // RTD application
-    if (fileType == FileType.TRANSACTIONS_SOURCE) {
-      return FileApplication.RTD;
-    }
-    if (fileType == FileType.TRANSACTIONS_CHUNK) {
+    if (fileType == FileType.TRANSACTIONS_SOURCE
+        || fileType == FileType.TRANSACTIONS_CHUNK) {
       return FileApplication.RTD;
     }
 
     // ADE types
-    if (fileType == FileType.AGGREGATES_SOURCE) {
-      return FileApplication.ADE;
-    }
-    if (fileType == FileType.AGGREGATES_CHUNK) {
-      return FileApplication.ADE;
-    }
-    if (fileType == FileType.AGGREGATES_DESTINATION) {
-      return FileApplication.ADE;
-    }
-    if (fileType == FileType.ADE_ACK) {
-      return FileApplication.ADE;
-    }
-    if (fileType == FileType.SENDER_ADE_ACK) {
+    if (fileType == FileType.AGGREGATES_SOURCE
+        || fileType == FileType.AGGREGATES_CHUNK
+        || fileType == FileType.AGGREGATES_DESTINATION
+        || fileType == FileType.ADE_ACK
+        || fileType == FileType.SENDER_ADE_ACK) {
       return FileApplication.ADE;
     }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
@@ -1,5 +1,8 @@
 package it.gov.pagopa.rtd.ms.rtdmsfileregister.adapter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.EventGridEvent;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileApplication;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataDTO;


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add a mechanism to obtain file size from an event of blob creation.

#### List of Changes
<!--- Describe your changes in detail -->
- add size extraction mechanism.
- update tests.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The metric of size is useful to understand variance of file sent.
The information comes within the blob creation event itself.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.