### PR TITLE
[TAE-85] Expose sender ADE ACK endpoint

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
@@ -174,5 +174,3 @@ public class BlobRegisterAdapter {
     return filename.split("\\.")[1];
   }
 }
-
-///blobServices/default/containers/ade/blobs/ack/CSTAR.99999.ADEACK.20220720.164559.001.csv

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestController.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestController.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtd.ms.rtdmsfileregister.controller;
 
 import io.swagger.annotations.Api;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataDTO;
+import java.util.List;
 import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -43,6 +44,10 @@ public interface RestController {
   @PutMapping(value = "/file-status", produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseStatus(HttpStatus.OK)
   FileMetadataDTO updateFileMetadata(@NotNull @RequestBody FileMetadataDTO metedata);
+
+  @GetMapping(value = "/sender-ade-ack", produces = MediaType.APPLICATION_JSON_VALUE)
+  @ResponseStatus(HttpStatus.OK)
+  List<String> senderAdeACKList(@NotNull @RequestParam String sender);
 
   @ResponseStatus(HttpStatus.NOT_FOUND)
   class FilenameNotPresent extends RuntimeException {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerImpl.java
@@ -3,6 +3,7 @@ package it.gov.pagopa.rtd.ms.rtdmsfileregister.controller;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataDTO;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.service.FileMetadataService;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
@@ -64,6 +65,13 @@ class RestControllerImpl implements
     }
 
     return deleted;
+  }
+
+  @Override
+  public List<String> senderAdeACKList(@NotNull String sender) {
+    log.info("Received GET sender AdE ACK List for sender {}", sender);
+
+    return fileMetadataService.getSenderAdeAckList(sender);
   }
 
   @Override

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/repository/FileMetadataRepository.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/repository/FileMetadataRepository.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtd.ms.rtdmsfileregister.repository;
 
 import com.mongodb.lang.NonNull;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataEntity;
+import java.util.List;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 /**
@@ -18,4 +19,6 @@ public interface FileMetadataRepository extends MongoRepository<FileMetadataEnti
   FileMetadataEntity findFirstByName(String filename);
 
   FileMetadataEntity removeByName(String filename);
+
+  List<FileMetadataEntity> findNamesBySenderAndTypeAndStatus(String sender, int type, int status);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataService.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.rtd.ms.rtdmsfileregister.service;
 
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataDTO;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,5 +14,7 @@ public interface FileMetadataService {
   FileMetadataDTO deleteFileMetadata(String filename);
 
   FileMetadataDTO updateFileMetadata(FileMetadataDTO metadata);
+
+  List<String> getSenderAdeAckList(String sender);
 
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceImpl.java
@@ -6,6 +6,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfileregister.controller.RestController.Filename
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataDTO;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataEntity;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.repository.FileMetadataRepository;
+import java.util.List;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -91,5 +92,11 @@ public class FileMetadataServiceImpl implements FileMetadataService {
     modelMapper.map(metadata, toBeUpdated, String.valueOf(FileMetadataEntity.class));
 
     return modelMapper.map(repository.save(toBeUpdated), FileMetadataDTO.class);
+  }
+
+  @Override
+  public List<String> getSenderAdeAckList(String sender) {
+    List<FileMetadataEntity> retrieved = repository.findNamesBySenderAndTypeAndStatus(sender, 6, 0);
+    return retrieved.stream().map(FileMetadataEntity::getName).collect(java.util.stream.Collectors.toList());
   }
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to add an endpoint for retrieving the names of the sender ade ack not downloaded yet.
#### List of Changes
<!--- Describe your changes in detail -->
- expose sender-ade-ack endpoint
- add a method to service for retrieving sender ade acks not downloaded and filtered by sender
- add a spring repository method to interact with data layer
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows us to expose sender ade ack information internally, ready to be invoked by the APIM.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.