### PR TITLE
[RTD-584] Divide download status

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerImpl.java
@@ -80,9 +80,10 @@ class RestControllerImpl implements
   public FileMetadataDTO setDownloadedSenderAdeAck(String filename) {
     log.info("Received PUT set downloaded SenderAdeAck for file {}", filename);
 
-    FileMetadataDTO updated = fileMetadataService.updateStatus(filename, 1);
+    FileMetadataDTO updated = fileMetadataService.updateStatus(filename,
+        FileStatus.DOWNLOAD_ENDED.getOrder());
 
-    if (updated.getStatus() != FileStatus.DOWNLOADED.getOrder()) {
+    if (updated.getStatus() != FileStatus.DOWNLOAD_ENDED.getOrder()) {
       throw new FileNotUpdated();
     }
     return updated;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/model/FileStatus.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/model/FileStatus.java
@@ -16,10 +16,17 @@ public enum FileStatus {
     }
   },
 
-  DOWNLOADED {
+  DOWNLOAD_STARTED {
     @Override
     public int getOrder() {
       return 1;
+    }
+  },
+
+  DOWNLOAD_ENDED {
+    @Override
+    public int getOrder() {
+      return 2;
     }
   };
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerTest.java
@@ -59,7 +59,9 @@ class RestControllerTest {
 
   static String UPDATED_TEST_FILE_METADATA = "{\"name\":\"presentFilename\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"hash\":\"0c8795b2d35316c58136ec2c62056e23e9e620e3b6ec6653661db7a76abd38b5\",\"status\":1}";
 
-  static String ACKED_TEST_FILE_METADATA = "{\"name\":\"presentFilename\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"hash\":\"0c8795b2d35316c58136ec2c62056e23e9e620e3b6ec6653661db7a76abd38b5\",\"status\":1}";
+  static String ACKED_TEST_FILE_METADATA =
+      "{\"name\":\"presentFilename\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"hash\":\"0c8795b2d35316c58136ec2c62056e23e9e620e3b6ec6653661db7a76abd38b5\",\"status\":"
+          + FileStatus.DOWNLOAD_ENDED.getOrder() + "}";
 
   static String UPDATE_FILE_METADATA = "{\"name\":\"presentFilename\",\"status\":5}";
 
@@ -137,17 +139,17 @@ class RestControllerTest {
         .getSenderAdeAckList(Arrays.asList("99999", "11111"));
 
     BDDMockito.doReturn(ackedTestFileMetadataDTO).when(fileMetadataService)
-        .updateStatus("presentFilename", 1);
+        .updateStatus("presentFilename", FileStatus.DOWNLOAD_ENDED.getOrder());
 
     BDDMockito.doThrow(FilenameNotPresent.class).when(fileMetadataService)
-        .updateStatus("notPresentFilename", 1);
+        .updateStatus("notPresentFilename", FileStatus.DOWNLOAD_ENDED.getOrder());
 
     BDDMockito.doThrow(StatusAlreadySet.class).when(fileMetadataService)
-        .updateStatus("alreadyDownloadedFilename", 1);
+        .updateStatus("alreadyDownloadedFilename", FileStatus.DOWNLOAD_ENDED.getOrder());
 
     BDDMockito.doReturn(modelMapper.map(senderAdeACKFileMetadataEntity1, FileMetadataDTO.class))
         .when(fileMetadataService)
-        .updateStatus("notUpdatedFilename", 1);
+        .updateStatus("notUpdatedFilename", FileStatus.DOWNLOAD_ENDED.getOrder());
   }
 
   @Test
@@ -366,7 +368,7 @@ class RestControllerTest {
     FileMetadataDTO acked = objectMapper.readValue(result.getResponse().getContentAsString(),
         FileMetadataDTO.class);
 
-    assertEquals(FileStatus.DOWNLOADED.getOrder(), acked.getStatus());
+    assertEquals(FileStatus.DOWNLOAD_ENDED.getOrder(), acked.getStatus());
     assertEquals(ackedTestFileMetadataDTO, acked);
     BDDMockito.verify(fileMetadataService)
         .updateStatus(Mockito.any(String.class), Mockito.any(Integer.class));

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -25,6 +25,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfileregister.controller.RestController.Filename
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.controller.RestController.StatusAlreadySet;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataDTO;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadataEntity;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileStatus;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.SenderAdeAckListDTO;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.repository.FileMetadataRepository;
 import java.util.List;
@@ -254,17 +255,21 @@ class FileMetadataServiceTest {
 
   @Test
   void updateAfterSenderAdeAckDownload() {
-    FileMetadataDTO result = service.updateStatus("presentFilename", 1);
+    FileMetadataDTO result = service.updateStatus("presentFilename",
+        FileStatus.DOWNLOAD_ENDED.getOrder());
     assertNotNull(result);
+    assertEquals(FileStatus.DOWNLOAD_ENDED.getOrder(), result.getStatus());
   }
 
   @Test
   void updateAfterSenderAdeAckDownloadNullFilename() {
-    assertThrows(FilenameNotPresent.class, () -> service.updateStatus("missingFilename", 1));
+    assertThrows(FilenameNotPresent.class,
+        () -> service.updateStatus("missingFilename", FileStatus.DOWNLOAD_ENDED.getOrder()));
   }
 
   @Test
   void updateAfterSenderAdeAckAlreadyDownloaded() {
-    assertThrows(StatusAlreadySet.class, () -> service.updateStatus("presentFilename", 0));
+    assertThrows(StatusAlreadySet.class,
+        () -> service.updateStatus("presentFilename", FileStatus.SUCCESS.getOrder()));
   }
 }

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -170,7 +170,7 @@ class FileMetadataServiceTest {
         objectMapper.readValue(metadataUpdatesJSON, FileMetadataDTO.class));
 
     assertNotNull(updated);
-    assertEquals(1, (int) updated.getStatus());
+    assertEquals(FileStatus.DOWNLOAD_STARTED.getOrder(), (int) updated.getStatus());
     verify(fileMetadataRepository).findFirstByName(anyString());
     verify(fileMetadataRepository).removeByName(anyString());
     verify(fileMetadataRepository).save(any(FileMetadataEntity.class));

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -263,13 +263,15 @@ class FileMetadataServiceTest {
 
   @Test
   void updateAfterSenderAdeAckDownloadNullFilename() {
+    int newStatus = FileStatus.DOWNLOAD_ENDED.getOrder();
     assertThrows(FilenameNotPresent.class,
-        () -> service.updateStatus("missingFilename", FileStatus.DOWNLOAD_ENDED.getOrder()));
+        () -> service.updateStatus("missingFilename", newStatus));
   }
 
   @Test
   void updateAfterSenderAdeAckAlreadyDownloaded() {
+    int newStatus = FileStatus.SUCCESS.getOrder();
     assertThrows(StatusAlreadySet.class,
-        () -> service.updateStatus("presentFilename", FileStatus.SUCCESS.getOrder()));
+        () -> service.updateStatus("presentFilename", newStatus));
   }
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to divide the DOWNLOADED status in 2 status: DOWNLOAD_STARTED and DOWNLOAD_ENDED.
#### List of Changes
<!--- Describe your changes in detail -->
- change FileStatus enum
- update controller to set DOWNLOAD_ENDED if explicit ack endpoint is called.
- update test.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows to grant retro-compatibility to Batch Service 1.2.5 during sender ade ack download. 
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
