### PR TITLE
feat: [RTD-842] Parent naming convention

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/AppConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/AppConfiguration.java
@@ -1,0 +1,15 @@
+package it.gov.pagopa.rtd.ms.rtdmsfileregister;
+
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.DefaultNamingPolicy;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.NamingConventionPolicy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfiguration {
+
+  @Bean
+  NamingConventionPolicy namingConventionPolicy() {
+    return new DefaultNamingPolicy();
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/DefaultNamingPolicy.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/DefaultNamingPolicy.java
@@ -1,0 +1,53 @@
+package it.gov.pagopa.rtd.ms.rtdmsfileregister.domain;
+
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileType;
+import org.springframework.data.util.Pair;
+
+public class DefaultNamingPolicy implements NamingConventionPolicy {
+  @Override
+  public String extractParentFileName(String filename, FileType fileType) {
+    if (fileType == FileType.TRANSACTIONS_SOURCE
+            || fileType == FileType.AGGREGATES_SOURCE
+            || fileType == FileType.ADE_ACK
+    ) {
+      return filename;
+    }
+    if (fileType == FileType.AGGREGATES_CHUNK) {
+      final var parts = filename.split("\\.");
+      final var chunkInfo = extractChunkInfo(parts);
+      final var parentChunkInfo = chunkInfo.getFirst().equals("00")
+              ? "" : String.format(".%s", chunkInfo.getFirst());
+      return "ADE." + parts[1] + ".TRNLOG." + parts[2] + "." + parts[3] + "." + parts[4]
+              + parentChunkInfo
+              + ".csv.pgp";
+    }
+    if (fileType == FileType.TRANSACTIONS_CHUNK) {
+      return filename.replaceAll("\\.(\\d)+\\.decrypted", "");
+    }
+    if (fileType == FileType.AGGREGATES_DESTINATION) {
+      String[] parts = filename.replace(".gz", "").split("\\.");
+      final var chunkInfo = extractChunkInfo(parts);
+      final var parentChunkInfo = chunkInfo.getFirst().equals("00")
+              ? "" : String.format(".%s", chunkInfo.getFirst());
+      //return "AGGADE." + parts[1] + "." + parts[2] + "." + parts[3] + "." + parts[4] + ".csv.pgp";
+      return "ADE." + parts[1] + ".TRNLOG." + parts[2] + "." + parts[3] + "." + parts[4]
+              + parentChunkInfo
+              + ".csv.pgp";
+    }
+    if (fileType == FileType.SENDER_ADE_ACK) {
+      String originalAdeAck = filename.replaceFirst(filename.split("\\.")[1], "")
+              .replaceFirst(filename.split("\\.")[2], "")
+              .replaceFirst("\\.", "").replaceFirst("\\.", "") + ".gz";
+      return "CSTAR.".concat(originalAdeAck);
+    }
+    return null;
+  }
+
+  private Pair<String, String> extractChunkInfo(String[] parts) {
+    // verify if contains chunk info
+    if (parts.length >= 5 && parts[5].matches("\\d{5}")) {
+      return Pair.of(parts[5].substring(0, 2), parts[5].substring(2, 5));
+    }
+    return Pair.of("00", "000");
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/NamingConventionPolicy.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/NamingConventionPolicy.java
@@ -1,0 +1,7 @@
+package it.gov.pagopa.rtd.ms.rtdmsfileregister.domain;
+
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileType;
+
+public interface NamingConventionPolicy {
+  String extractParentFileName(String filename, FileType fileType);
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/DefaultNamingPolicyTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/DefaultNamingPolicyTest.java
@@ -1,0 +1,46 @@
+package it.gov.pagopa.rtd.ms.rtdmsfileregister.domain;
+
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultNamingPolicyTest {
+
+  private NamingConventionPolicy defaultPolicy;
+
+  @BeforeEach
+  public void setUp() {
+    defaultPolicy = new DefaultNamingPolicy();
+  }
+
+  // input, type, expected output
+  @ParameterizedTest
+  @CsvSource({
+          "ADE.99999.TRNLOG.20220503.172038.467.01.csv.pgp, AGGREGATES_SOURCE, ADE.99999.TRNLOG.20220503.172038.467.01.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.01000, AGGREGATES_CHUNK, ADE.99999.TRNLOG.20220503.172038.467.01.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.01000.gz, AGGREGATES_DESTINATION, ADE.99999.TRNLOG.20220503.172038.467.01.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.02010, AGGREGATES_CHUNK, ADE.99999.TRNLOG.20220503.172038.467.02.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.02005.gz, AGGREGATES_DESTINATION, ADE.99999.TRNLOG.20220503.172038.467.02.csv.pgp",
+  })
+  void givenFilenameWithBatchChunkThenExtractRightParentFile(String filename, FileType fileType, String expectedParent) {
+    final var parentFilename = defaultPolicy.extractParentFileName(filename, fileType);
+    assertThat(parentFilename).isEqualTo(expectedParent);
+  }
+
+
+  @ParameterizedTest
+  @CsvSource({
+          "ADE.99999.TRNLOG.20220503.172038.467.csv.pgp, AGGREGATES_SOURCE, ADE.99999.TRNLOG.20220503.172038.467.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.00000, AGGREGATES_CHUNK, ADE.99999.TRNLOG.20220503.172038.467.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.00020, AGGREGATES_CHUNK, ADE.99999.TRNLOG.20220503.172038.467.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.00000.gz, AGGREGATES_DESTINATION, ADE.99999.TRNLOG.20220503.172038.467.csv.pgp",
+          "AGGADE.99999.20220503.172038.467.00010.gz, AGGREGATES_DESTINATION, ADE.99999.TRNLOG.20220503.172038.467.csv.pgp",
+  })
+  void givenFilenameWithNoBatchChunkThenExtractRightParentFile(String filename, FileType fileType, String expectedParent) {
+    final var parentFilename = defaultPolicy.extractParentFileName(filename, fileType);
+    assertThat(parentFilename).isEqualTo(expectedParent);
+  }
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/event/EventHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/event/EventHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.AppConfiguration;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.adapter.BlobRegisterAdapter;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.EventGridData;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.EventGridEvent;
@@ -41,7 +42,7 @@ import org.springframework.test.context.TestPropertySource;
 @EmbeddedKafka(topics = {"rtd-platform-events"}, partitions = 1,
     bootstrapServersProperty = "spring.embedded.kafka.brokers")
 @EnableAutoConfiguration(exclude = {TestSupportBinderAutoConfiguration.class})
-@ContextConfiguration(classes = {EventHandler.class})
+@ContextConfiguration(classes = {EventHandler.class, AppConfiguration.class})
 @TestPropertySource(value = {"classpath:application-test.yml"}, inheritProperties = false)
 @DirtiesContext
 class EventHandlerTest {

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.AppConfiguration;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.RtdMsFileRegisterApplication;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.controller.RestController.DTOViolationException;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.controller.RestController.EmptyFilenameException;
@@ -41,7 +42,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 
 @DataMongoTest
-@ContextConfiguration(classes = {FileMetadataServiceImpl.class, RtdMsFileRegisterApplication.class})
+@ContextConfiguration(classes = {AppConfiguration.class, FileMetadataServiceImpl.class, RtdMsFileRegisterApplication.class})
 @EntityScan("it.gov.pagopa.rtd.ms.rtdmsfileregister.model")
 class FileMetadataServiceTest {
 


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR abstracts naming convention strategies using a policy interface (`NamingConvetionPolicy`). Actually this interface defines a strategy to extract parent file name, but can be enriched by others methods related to naming convention manipulation. A `DefaultNamingConvetionPolicy` are provided as a copy of `extractParent` method defined in `BlobRegisterAdapter`. As future improvement the idea is to create different naming convention policy (one for Transaction, one for ADE) and use it inside `BlobRegisterAdapter`. This approach improve the test isolation cause allow to test a single naming convention policy.

#### List of Changes
<!--- Describe your changes in detail -->
- added `DefaultNamingConvetionPolicy` which handles batch service chunk case
- unit test to test the `DefaultNamingConvetionPolicy` in isolation

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [x] Unit 
  - [ ] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [ ] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [x] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
