### PR TITLE
breaking: [RTD-2471] propagate file path to reporter

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@7bfb19c48fc334d3dacb072cf982e81535041209 #v3.4.6
+      - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 #v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 #v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Release
-        uses: cycjimmy/semantic-release-action@8e58d20d0f6c8773181f43eb74d6a05e3099571d #v3.4.2
+        uses: cycjimmy/semantic-release-action@61680d0e9b02ff86f5648ade99e01be17f0260a4 #v4.0.0
         with:
           semantic_version: 18.0.0
           extra_plugins: |

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -33,12 +33,12 @@ jobs:
     environment: dev
     steps:
       - name: Checkout the code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       - name: Build the Docker image
         run: docker build . --file ${{ env.DOCKERFILE }} --target cve --tag localbuild/testimage:latest
       - name: Run the Trivy scan action itself with GitHub Advanced Security code scanning integration enabled
         id: scan
-        uses: aquasecurity/trivy-action@fbd16365eb88e12433951383f5e99bd901fc618f #v0.12.0
+        uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d #v0.18.0
         with:
           image-ref: "localbuild/testimage:latest"
           format: 'sarif'
@@ -62,7 +62,7 @@ jobs:
       - name: Send notification to Slack
         id: slack
         if: always() && github.event_name == 'schedule' && steps.cve-threshold.outcome == 'failure'
-        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 #v1.24.0
+        uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 #v1.25.0
         with:
           payload: |
             {

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>it.gov.pagopa.rtd.ms</groupId>
 	<artifactId>rtd-ms-file-register</artifactId>
-	<version>1.2.1</version>
+	<version>2.0.0</version>
 	<name>rtd-ms-file-register</name>
 	<description>Micro-service designed to register the state of each and every file ingested by RTD</description>
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/AppConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/AppConfiguration.java
@@ -3,7 +3,9 @@ package it.gov.pagopa.rtd.ms.rtdmsfileregister;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.adapter.FileChangedEventListener;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.DefaultNamingPolicy;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.NamingConventionPolicy;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events.DecryptedEventCommand;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events.FileChangedFactory;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.repository.FileMetadataRepository;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,13 +21,19 @@ public class AppConfiguration {
   }
 
   @Bean
-  FileChangedFactory fileChangedFactory() {
-    return FileChangedFactory.typeStatusBased();
+  FileChangedFactory fileChangedFactory(DecryptedEventCommand command) {
+    return FileChangedFactory.typeStatusBased(command);
   }
 
   @Bean
   FileChangedEventListener fileChangedEventListener(StreamBridge streamBridge) {
     return new FileChangedEventListener(streamBridge, PROJECTOR_BINDING_NAME);
+  }
+
+  @Bean
+  DecryptedEventCommand decryptedEventCommand(FileMetadataRepository repository,
+      NamingConventionPolicy namingPolicy) {
+    return new DecryptedEventCommand(repository, namingPolicy);
   }
 
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/adapter/BlobRegisterAdapter.java
@@ -104,32 +104,7 @@ public class BlobRegisterAdapter {
   }
 
   public FileType evaluateContainer(String containerName) {
-    // RTD types
-    if (containerName.matches("rtd-transactions-[a-z0-9]{44}")) {
-      return FileType.TRANSACTIONS_SOURCE;
-    }
-    if (containerName.matches("rtd-transactions-decrypted")) {
-      return FileType.TRANSACTIONS_CHUNK;
-    }
-
-    // ADE types
-    if (containerName.matches("ade-transactions-[a-z0-9]{44}")) {
-      return FileType.AGGREGATES_SOURCE;
-    }
-    if (containerName.matches("ade-transactions-decrypted")) {
-      return FileType.AGGREGATES_CHUNK;
-    }
-    if (containerName.matches("ade/in")) {
-      return FileType.AGGREGATES_DESTINATION;
-    }
-    if (containerName.matches("ade/ack")) {
-      return FileType.ADE_ACK;
-    }
-    if (containerName.matches("sender-ade-ack/[A-Z0-9]{5}")) {
-      return FileType.SENDER_ADE_ACK;
-    }
-
-    return FileType.UNKNOWN;
+    return namingConventionPolicy.extractFileTypeFromContainer(containerName);
   }
 
   public FileApplication evaluateApplication(FileType fileType) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/DefaultNamingPolicy.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/DefaultNamingPolicy.java
@@ -35,6 +35,41 @@ public class DefaultNamingPolicy implements NamingConventionPolicy {
     return null;
   }
 
+  @Override
+  public String extractParentFileName(String filename, String container) {
+    return extractParentFileName(filename, extractFileTypeFromContainer(container));
+  }
+
+  @Override
+  public FileType extractFileTypeFromContainer(String containerName) {
+    // RTD types
+    if (containerName.matches("rtd-transactions-[a-z0-9]{44}")) {
+      return FileType.TRANSACTIONS_SOURCE;
+    }
+    if (containerName.matches("rtd-transactions-decrypted")) {
+      return FileType.TRANSACTIONS_CHUNK;
+    }
+
+    // ADE types
+    if (containerName.matches("ade-transactions-[a-z0-9]{44}")) {
+      return FileType.AGGREGATES_SOURCE;
+    }
+    if (containerName.matches("ade-transactions-decrypted")) {
+      return FileType.AGGREGATES_CHUNK;
+    }
+    if (containerName.matches("ade/in")) {
+      return FileType.AGGREGATES_DESTINATION;
+    }
+    if (containerName.matches("ade/ack")) {
+      return FileType.ADE_ACK;
+    }
+    if (containerName.matches("sender-ade-ack/[A-Z0-9]{5}")) {
+      return FileType.SENDER_ADE_ACK;
+    }
+
+    return FileType.UNKNOWN;
+  }
+
   private Optional<String> extractBatchServiceChunk(String[] parts) {
     final var chunkInfo = extractChunkInfo(parts);
     return chunkInfo.getFirst().equals("00")

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/NamingConventionPolicy.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/NamingConventionPolicy.java
@@ -4,4 +4,6 @@ import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileType;
 
 public interface NamingConventionPolicy {
   String extractParentFileName(String filename, FileType fileType);
+  String extractParentFileName(String filename, String container);
+  FileType extractFileTypeFromContainer(String containerName);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/DecryptedEventCommand.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/DecryptedEventCommand.java
@@ -1,0 +1,31 @@
+package it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events;
+
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.NamingConventionPolicy;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadata;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.repository.FileMetadataRepository;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class DecryptedEventCommand implements Function<FileMetadata, FileChanged> {
+
+  private final FileMetadataRepository repository;
+  private final NamingConventionPolicy namingConventionPolicy;
+
+  @Override
+  public FileChanged apply(FileMetadata fileMetadata) {
+
+    // retrieve pgp container from parent
+    var parentFile = repository.findFirstByName(
+        namingConventionPolicy.extractParentFileName(fileMetadata.getName(),
+            fileMetadata.getContainer()));
+
+    // todo if absent then raise error?
+
+    return new FileChanged("/" + parentFile.getContainer() + "/" + fileMetadata.getParent(),
+        fileMetadata.getSender(), fileMetadata.getSize(), fileMetadata.getReceiveTimestamp(),
+        StatusMapper.getFileChangedTypeFromFile(fileMetadata));
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/FileChanged.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/FileChanged.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 @Data
 public class FileChanged {
 
-  private final String fileName;
+  private final String filePath;
   private final String sender;
   private final Long size;
   private final LocalDateTime receiveTimestamp;

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/FileChangedFactory.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/FileChangedFactory.java
@@ -9,8 +9,8 @@ import java.util.Optional;
  */
 public interface FileChangedFactory {
 
-  static FileChangedFactory typeStatusBased() {
-    return new TypeStatusFileChangedFactory();
+  static FileChangedFactory typeStatusBased(DecryptedEventCommand command) {
+    return new TypeStatusFileChangedFactory(command);
   }
 
   Optional<FileChanged> createFrom(FileMetadata fileMetadata);

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/StatusMapper.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/StatusMapper.java
@@ -1,0 +1,25 @@
+package it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events;
+
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events.FileChanged.Type;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadata;
+import jakarta.annotation.Nullable;
+import java.util.Map;
+
+public class StatusMapper {
+
+  private static final Map<String, Type> statusConversionMap = Map.of(
+      "2_0", FileChanged.Type.RECEIVED,
+      "3_0", FileChanged.Type.DECRYPTED,
+      "4_0", FileChanged.Type.SENT_TO_ADE,
+      "6_0", FileChanged.Type.ACK_TO_DOWNLOAD,
+      "6_2", FileChanged.Type.ACK_DOWNLOADED
+  );
+
+  private StatusMapper() {
+  }
+
+  @Nullable
+  public static FileChanged.Type getFileChangedTypeFromFile(FileMetadata fileMetadata) {
+    return statusConversionMap.get(String.format("%d_%d", fileMetadata.getType(), fileMetadata.getStatus()));
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/TypeStatusFileChangedFactory.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/TypeStatusFileChangedFactory.java
@@ -1,14 +1,12 @@
 package it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events;
 
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadata;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * This is a factory which produce file changed events based on
- * file metadata's type and status
+ * This is a factory which produce file changed events based on file metadata's type and status
  */
 class TypeStatusFileChangedFactory implements FileChangedFactory {
 
@@ -26,7 +24,8 @@ class TypeStatusFileChangedFactory implements FileChangedFactory {
   @Override
   public Optional<FileChanged> createFrom(FileMetadata file) {
     return Optional.ofNullable(statusConversionMap.get(lookupKey(file)))
-            .map(type -> new FileChanged(file.getParent(), file.getSender(), file.getSize(), file.getReceiveTimestamp(), type));
+        .map(type -> new FileChanged("/" + file.getContainer() + "/" + file.getParent(),
+            file.getSender(), file.getSize(), file.getReceiveTimestamp(), type));
   }
 
   private String lookupKey(FileMetadata fileMetadata) {

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/TypeStatusFileChangedFactory.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/domain/events/TypeStatusFileChangedFactory.java
@@ -1,34 +1,30 @@
 package it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events;
 
+import static it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events.StatusMapper.getFileChangedTypeFromFile;
+
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.domain.events.FileChanged.Type;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.FileMetadata;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 /**
  * This is a factory which produce file changed events based on file metadata's type and status
  */
+@RequiredArgsConstructor
 class TypeStatusFileChangedFactory implements FileChangedFactory {
 
-  private final Map<String, FileChanged.Type> statusConversionMap;
-
-  public TypeStatusFileChangedFactory() {
-    statusConversionMap = new HashMap<>();
-    statusConversionMap.put("2_0", FileChanged.Type.RECEIVED);
-    statusConversionMap.put("3_0", FileChanged.Type.DECRYPTED);
-    statusConversionMap.put("4_0", FileChanged.Type.SENT_TO_ADE);
-    statusConversionMap.put("6_0", FileChanged.Type.ACK_TO_DOWNLOAD);
-    statusConversionMap.put("6_2", FileChanged.Type.ACK_DOWNLOADED);
-  }
+  private final DecryptedEventCommand decryptedEventCommand;
 
   @Override
   public Optional<FileChanged> createFrom(FileMetadata file) {
-    return Optional.ofNullable(statusConversionMap.get(lookupKey(file)))
-        .map(type -> new FileChanged("/" + file.getContainer() + "/" + file.getParent(),
-            file.getSender(), file.getSize(), file.getReceiveTimestamp(), type));
-  }
-
-  private String lookupKey(FileMetadata fileMetadata) {
-    return String.format("%d_%d", fileMetadata.getType(), fileMetadata.getStatus());
+    return Optional.ofNullable(getFileChangedTypeFromFile(file))
+        .map(type -> {
+          if (type == Type.DECRYPTED) {
+            return decryptedEventCommand.apply(file);
+          } else {
+            return new FileChanged("/" + file.getContainer() + "/" + file.getParent(),
+                file.getSender(), file.getSize(), file.getReceiveTimestamp(), type);
+          }
+        });
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/event/EventHandler.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/event/EventHandler.java
@@ -4,9 +4,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfileregister.adapter.BlobRegisterAdapter;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.EventGridEvent;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import lombok.Getter;
-
 import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,7 +27,6 @@ public class EventHandler {
   public Consumer<Message<List<EventGridEvent>>> blobStorageConsumer(BlobRegisterAdapter blobRegisterAdapter) {
     return message -> message.getPayload().stream()
         .filter(e -> "Microsoft.Storage.BlobCreated".equals(e.getEventType()))
-        .map(blobRegisterAdapter::evaluateEvent)
-        .collect(Collectors.toList());
+        .forEach(blobRegisterAdapter::evaluateEvent);
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/model/FileMetadata.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/model/FileMetadata.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import java.time.LocalDateTime;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import java.time.LocalDateTime;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,6 +21,10 @@ public class FileMetadata {
   @NotNull
   @NotBlank
   private String name;
+
+  @NotNull
+  @NotBlank
+  private String container;
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
   @JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/model/FileMetadata.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/model/FileMetadata.java
@@ -22,8 +22,6 @@ public class FileMetadata {
   @NotBlank
   private String name;
 
-  @NotNull
-  @NotBlank
   private String container;
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/controller/RestControllerTest.java
@@ -55,7 +55,7 @@ class RestControllerTest {
 
   static String SENDER_ADE_ACK_ENDPOINT = "/sender-ade-ack";
 
-  static String TEST_FILE_METADATA = "{\"name\":\"presentFilename\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"application\":0,\"size\":0,\"type\":0}";
+  static String TEST_FILE_METADATA = "{\"name\":\"presentFilename\",\"container\": \"ade-decrypted\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"application\":0,\"size\":0,\"type\":0}";
 
   static String UPDATED_TEST_FILE_METADATA = "{\"name\":\"presentFilename\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"hash\":\"0c8795b2d35316c58136ec2c62056e23e9e620e3b6ec6653661db7a76abd38b5\",\"status\":1}";
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/event/EventHandlerTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/event/EventHandlerTest.java
@@ -14,6 +14,7 @@ import it.gov.pagopa.rtd.ms.rtdmsfileregister.adapter.BlobRegisterAdapter;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.controller.RestController.FilenameAlreadyPresent;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.EventGridData;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.model.EventGridEvent;
+import it.gov.pagopa.rtd.ms.rtdmsfileregister.repository.FileMetadataRepository;
 import it.gov.pagopa.rtd.ms.rtdmsfileregister.service.FileMetadataService;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -59,7 +60,8 @@ class EventHandlerTest {
 
   @MockBean
   FileMetadataService fileMetadataService;
-
+  @MockBean
+  FileMetadataRepository repository;
   @SpyBean
   BlobRegisterAdapter blobRegisterAdapter;
 
@@ -326,7 +328,9 @@ class EventHandlerTest {
   @ExtendWith(OutputCaptureExtension.class)
   void fileAlreadyPresentWarning(CapturedOutput capturedOutput) {
     when(fileMetadataService.storeFileMetadata(any())).thenThrow(new FilenameAlreadyPresent());
-    String uri = "/blobServices/default/containers/" + "ade-transactions-32489876908u74bh781e2db57k098c5ad00000000000" + "/blobs/" + "ADE.99999.TRNLOG.20220503.172038.001.csv.pgp";
+    String uri = "/blobServices/default/containers/"
+        + "ade-transactions-32489876908u74bh781e2db57k098c5ad00000000000" + "/blobs/"
+        + "ADE.99999.TRNLOG.20220503.172038.001.csv.pgp";
 
     myEvent.setSubject(uri);
     myList = List.of(myEvent);
@@ -344,7 +348,8 @@ class EventHandlerTest {
   @ExtendWith(OutputCaptureExtension.class)
   void fileAlreadyPresentIgnoreWarning(CapturedOutput capturedOutput) {
     when(fileMetadataService.storeFileMetadata(any())).thenThrow(new FilenameAlreadyPresent());
-    String uri = "/blobServices/default/containers/" + "ade" + "/blobs/" + "ack/CSTAR.ADEACK.20220826.013326.014.OK";
+    String uri = "/blobServices/default/containers/" + "ade" + "/blobs/"
+        + "ack/CSTAR.ADEACK.20220826.013326.014.OK";
 
     myEvent.setSubject(uri);
     myList = List.of(myEvent);

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -230,7 +230,7 @@ class FileMetadataServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {
-      "{\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"container\": \"ade-decrypted\",\"status\":0,\"application\":0,\"size\":0,\"type\":0}",
+      "{\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"container\": \"ade-transactions-decrypted\",\"status\":0,\"application\":0,\"size\":0,\"type\":0}",
       "{\"name\":\"\",\"container\": \"ade-decrypted\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"type\":0,\"application\":0,\"size\":0}",
   })
   void updateKoEmptyFilename(String body) throws JsonProcessingException {

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -309,13 +309,24 @@ class FileMetadataServiceTest {
 
     @Test
     void whenFileIsSplitThenFireDecryptedEvent() {
+      final var mockedEntity = new FileMetadataEntity();
+      mockedEntity.setName("parentFilename");
+      mockedEntity.setContainer("parentContainer");
+      mockedEntity.setType(FileType.AGGREGATES_CHUNK.getOrder());
+      mockedEntity.setStatus(FileStatus.SUCCESS.getOrder());
+      mockedEntity.setReceiveTimestamp(LocalDateTime.now());
+      mockedEntity.setSender("12345");
+      mockedEntity.setParent("parent");
+      mockedEntity.setApplication(FileApplication.ADE.getOrder());
+      mockedEntity.setSize(1234L);
+      when(fileMetadataRepository.findFirstByName(null)).thenReturn(mockedEntity);
       final var fileSplitEvent = mockFileEventMetadata(FileType.AGGREGATES_CHUNK,
           FileStatus.SUCCESS);
 
       service.storeFileMetadata(fileSplitEvent);
       Mockito.verify(fileChangedEventListener).handleFileChanged(
           new FileChanged(
-              "/" + fileSplitEvent.getContainer() + "/" + fileSplitEvent.getParent(),
+              "/" + mockedEntity.getContainer() + "/" + fileSplitEvent.getParent(),
               fileSplitEvent.getSender(),
               fileSplitEvent.getSize(),
               fileSplitEvent.getReceiveTimestamp(),

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -80,7 +80,7 @@ class FileMetadataServiceTest {
 
   static String newTestFileMetadataJSON = "{\"name\":\"newFilename\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"hash\":\"090ed8c1103eb1dc4bae0ac2aa608fa5c085648438b7d38cfc238b9a98eba545\",\"status\":1,\"application\":0,\"size\":5555,\"type\":0}";
 
-  private String metadataUpdatesJSON = "{\"name\":\"presentFilename\",\"container\": \"ade-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
+  private String metadataUpdatesJSON = "{\"name\":\"presentFilename\",\"container\": \"ade-transactions-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
 
   private String notPresentMetadataUpdatesJSON = "{\"name\":\"notPresentFilename\",\"container\": \"ade-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -231,7 +231,7 @@ class FileMetadataServiceTest {
   @ParameterizedTest
   @ValueSource(strings = {
       "{\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"container\": \"ade-transactions-decrypted\",\"status\":0,\"application\":0,\"size\":0,\"type\":0}",
-      "{\"name\":\"\",\"container\": \"ade-decrypted\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"type\":0,\"application\":0,\"size\":0}",
+      "{\"name\":\"\",\"container\": \"ade-transactions-decrypted\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"type\":0,\"application\":0,\"size\":0}",
   })
   void updateKoEmptyFilename(String body) throws JsonProcessingException {
     ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -82,7 +82,7 @@ class FileMetadataServiceTest {
 
   private String metadataUpdatesJSON = "{\"name\":\"presentFilename\",\"container\": \"ade-transactions-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
 
-  private String notPresentMetadataUpdatesJSON = "{\"name\":\"notPresentFilename\",\"container\": \"ade-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
+  private String notPresentMetadataUpdatesJSON = "{\"name\":\"notPresentFilename\",\"container\": \"ade-transactions-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
 
 
   @BeforeEach

--- a/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/rtdmsfileregister/service/FileMetadataServiceTest.java
@@ -48,7 +48,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 
 @DataMongoTest
-@ContextConfiguration(classes = {AppConfiguration.class, FileMetadataServiceImpl.class, RtdMsFileRegisterApplication.class})
+@ContextConfiguration(classes = {AppConfiguration.class, FileMetadataServiceImpl.class,
+    RtdMsFileRegisterApplication.class})
 @EntityScan("it.gov.pagopa.rtd.ms.rtdmsfileregister.model")
 class FileMetadataServiceTest {
 
@@ -79,9 +80,9 @@ class FileMetadataServiceTest {
 
   static String newTestFileMetadataJSON = "{\"name\":\"newFilename\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"hash\":\"090ed8c1103eb1dc4bae0ac2aa608fa5c085648438b7d38cfc238b9a98eba545\",\"status\":1,\"application\":0,\"size\":5555,\"type\":0}";
 
-  private String metadataUpdatesJSON = "{\"name\":\"presentFilename\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
+  private String metadataUpdatesJSON = "{\"name\":\"presentFilename\",\"container\": \"ade-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
 
-  private String notPresentMetadataUpdatesJSON = "{\"name\":\"notPresentFilename\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
+  private String notPresentMetadataUpdatesJSON = "{\"name\":\"notPresentFilename\",\"container\": \"ade-decrypted\",\"status\":1,\"application\":0,\"size\":0,\"type\":0}";
 
 
   @BeforeEach
@@ -229,8 +230,8 @@ class FileMetadataServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {
-      "{\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"application\":0,\"size\":0,\"type\":0}",
-      "{\"name\":\"\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"type\":0,\"application\":0,\"size\":0}",
+      "{\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"container\": \"ade-decrypted\",\"status\":0,\"application\":0,\"size\":0,\"type\":0}",
+      "{\"name\":\"\",\"container\": \"ade-decrypted\",\"receiveTimestamp\":\"2020-08-06T11:19:16.500\",\"status\":0,\"type\":0,\"application\":0,\"size\":0}",
   })
   void updateKoEmptyFilename(String body) throws JsonProcessingException {
     ObjectMapper objectMapper = new ObjectMapper();
@@ -288,51 +289,55 @@ class FileMetadataServiceTest {
 
   @Nested
   class FireEventTests {
+
     @Test
     void whenFileIsUploadedThenFireReceivedEvent() {
-      final var fileUploadEvent = mockFileEventMetadata(FileType.AGGREGATES_SOURCE, FileStatus.SUCCESS);
+      final var fileUploadEvent = mockFileEventMetadata(FileType.AGGREGATES_SOURCE,
+          FileStatus.SUCCESS);
 
       service.storeFileMetadata(fileUploadEvent);
       Mockito.verify(fileChangedEventListener).handleFileChanged(
-              new FileChanged(
-                      fileUploadEvent.getParent(),
-                      fileUploadEvent.getSender(),
-                      fileUploadEvent.getSize(),
-                      fileUploadEvent.getReceiveTimestamp(),
-                      FileChanged.Type.RECEIVED
-              )
+          new FileChanged(
+              "/" + fileUploadEvent.getContainer() + "/" + fileUploadEvent.getParent(),
+              fileUploadEvent.getSender(),
+              fileUploadEvent.getSize(),
+              fileUploadEvent.getReceiveTimestamp(),
+              FileChanged.Type.RECEIVED
+          )
       );
     }
 
     @Test
     void whenFileIsSplitThenFireDecryptedEvent() {
-      final var fileSplitEvent = mockFileEventMetadata(FileType.AGGREGATES_CHUNK, FileStatus.SUCCESS);
+      final var fileSplitEvent = mockFileEventMetadata(FileType.AGGREGATES_CHUNK,
+          FileStatus.SUCCESS);
 
       service.storeFileMetadata(fileSplitEvent);
       Mockito.verify(fileChangedEventListener).handleFileChanged(
-              new FileChanged(
-                      fileSplitEvent.getParent(),
-                      fileSplitEvent.getSender(),
-                      fileSplitEvent.getSize(),
-                      fileSplitEvent.getReceiveTimestamp(),
-                      FileChanged.Type.DECRYPTED
-              )
+          new FileChanged(
+              "/" + fileSplitEvent.getContainer() + "/" + fileSplitEvent.getParent(),
+              fileSplitEvent.getSender(),
+              fileSplitEvent.getSize(),
+              fileSplitEvent.getReceiveTimestamp(),
+              FileChanged.Type.DECRYPTED
+          )
       );
     }
 
     @Test
     void whenFileIsMovedToAdeThenFireSentToAdeEvent() {
-      final var moveToAdeEvent = mockFileEventMetadata(FileType.AGGREGATES_DESTINATION, FileStatus.SUCCESS);
+      final var moveToAdeEvent = mockFileEventMetadata(FileType.AGGREGATES_DESTINATION,
+          FileStatus.SUCCESS);
 
       service.storeFileMetadata(moveToAdeEvent);
       verify(fileChangedEventListener).handleFileChanged(
-              new FileChanged(
-                      moveToAdeEvent.getParent(),
-                      moveToAdeEvent.getSender(),
-                      moveToAdeEvent.getSize(),
-                      moveToAdeEvent.getReceiveTimestamp(),
-                      FileChanged.Type.SENT_TO_ADE
-              )
+          new FileChanged(
+              "/" + moveToAdeEvent.getContainer() + "/" + moveToAdeEvent.getParent(),
+              moveToAdeEvent.getSender(),
+              moveToAdeEvent.getSize(),
+              moveToAdeEvent.getReceiveTimestamp(),
+              FileChanged.Type.SENT_TO_ADE
+          )
       );
     }
 
@@ -341,53 +346,60 @@ class FileMetadataServiceTest {
       final var ackReadyEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK, FileStatus.SUCCESS);
       service.storeFileMetadata(ackReadyEvent);
       verify(fileChangedEventListener).handleFileChanged(
-              new FileChanged(
-                      ackReadyEvent.getParent(),
-                      ackReadyEvent.getSender(),
-                      ackReadyEvent.getSize(),
-                      ackReadyEvent.getReceiveTimestamp(),
-                      FileChanged.Type.ACK_TO_DOWNLOAD
-              )
+          new FileChanged(
+              "/" + ackReadyEvent.getContainer() + "/" + ackReadyEvent.getParent(),
+              ackReadyEvent.getSender(),
+              ackReadyEvent.getSize(),
+              ackReadyEvent.getReceiveTimestamp(),
+              FileChanged.Type.ACK_TO_DOWNLOAD
+          )
       );
     }
 
     @Test
     void whenAckIsImplicitAckedThenFireAckDownloadedEvent() {
-      final var ackAckedEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK, FileStatus.DOWNLOAD_ENDED);
-      when(fileMetadataRepository.findFirstByName("filename")).thenReturn(modelMapper.map(ackAckedEvent, FileMetadataEntity.class));
+      final var ackAckedEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK,
+          FileStatus.DOWNLOAD_ENDED);
+      when(fileMetadataRepository.findFirstByName("filename"))
+          .thenReturn(modelMapper.map(ackAckedEvent, FileMetadataEntity.class));
       service.updateFileMetadata(ackAckedEvent);
       verify(fileChangedEventListener).handleFileChanged(
-              new FileChanged(
-                      ackAckedEvent.getParent(),
-                      ackAckedEvent.getSender(),
-                      ackAckedEvent.getSize(),
-                      ackAckedEvent.getReceiveTimestamp(),
-                      FileChanged.Type.ACK_DOWNLOADED
-              )
+          new FileChanged(
+              "/" + ackAckedEvent.getContainer() + "/" + ackAckedEvent.getParent(),
+              ackAckedEvent.getSender(),
+              ackAckedEvent.getSize(),
+              ackAckedEvent.getReceiveTimestamp(),
+              FileChanged.Type.ACK_DOWNLOADED
+          )
       );
     }
 
     @Test
     void whenAckIsExplicitAckedThenFireAckDownloadEvent() {
-      final var ackReadyEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK, FileStatus.DOWNLOAD_STARTED);
-      final var ackAckedEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK, FileStatus.DOWNLOAD_ENDED);
-      when(fileMetadataRepository.findFirstByName("filename")).thenReturn(modelMapper.map(ackReadyEvent, FileMetadataEntity.class));
+      final var ackReadyEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK,
+          FileStatus.DOWNLOAD_STARTED);
+      final var ackAckedEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK,
+          FileStatus.DOWNLOAD_ENDED);
+      when(fileMetadataRepository.findFirstByName("filename"))
+          .thenReturn(modelMapper.map(ackReadyEvent, FileMetadataEntity.class));
       service.updateStatus(ackAckedEvent.getName(), FileStatus.DOWNLOAD_ENDED.getOrder());
       verify(fileChangedEventListener).handleFileChanged(
-              new FileChanged(
-                      ackAckedEvent.getParent(),
-                      ackAckedEvent.getSender(),
-                      ackAckedEvent.getSize(),
-                      ackAckedEvent.getReceiveTimestamp(),
-                      FileChanged.Type.ACK_DOWNLOADED
-              )
+          new FileChanged(
+              "/" + ackAckedEvent.getContainer() + "/" + ackAckedEvent.getParent(),
+              ackAckedEvent.getSender(),
+              ackAckedEvent.getSize(),
+              ackAckedEvent.getReceiveTimestamp(),
+              FileChanged.Type.ACK_DOWNLOADED
+          )
       );
     }
 
     @Test
     void whenAckIsExplicitAckedThenFireAckDownloadEventEvenIfItHasBeenAlreadyDownloaded() {
-      final var ackAckedEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK, FileStatus.DOWNLOAD_ENDED);
-      when(fileMetadataRepository.findFirstByName("filename")).thenReturn(modelMapper.map(ackAckedEvent, FileMetadataEntity.class));
+      final var ackAckedEvent = mockFileEventMetadata(FileType.SENDER_ADE_ACK,
+          FileStatus.DOWNLOAD_ENDED);
+      when(fileMetadataRepository.findFirstByName("filename"))
+          .thenReturn(modelMapper.map(ackAckedEvent, FileMetadataEntity.class));
 
       service.updateStatus("filename", FileStatus.DOWNLOAD_ENDED.getOrder());
 
@@ -404,6 +416,7 @@ class FileMetadataServiceTest {
     private FileMetadataDTO mockFileEventMetadata(FileType type, FileStatus status) {
       final var fileMetadataDTO = new FileMetadataDTO();
       fileMetadataDTO.setName("filename");
+      fileMetadataDTO.setContainer("container");
       fileMetadataDTO.setType(type.getOrder());
       fileMetadataDTO.setStatus(status.getOrder());
       fileMetadataDTO.setReceiveTimestamp(LocalDateTime.now());
@@ -411,7 +424,8 @@ class FileMetadataServiceTest {
       fileMetadataDTO.setParent("parent");
       fileMetadataDTO.setApplication(FileApplication.ADE.getOrder());
       fileMetadataDTO.setSize(1234L);
-      when(fileMetadataRepository.save(any())).thenReturn(modelMapper.map(fileMetadataDTO, FileMetadataEntity.class));
+      when(fileMetadataRepository.save(any()))
+          .thenReturn(modelMapper.map(fileMetadataDTO, FileMetadataEntity.class));
       return fileMetadataDTO;
     }
   }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     activate:
       on-profile: test
   cloud:
+    function:
+      definition: blobStorageConsumer
     stream:
       bindings:
         blobStorageConsumer-in-0: # name must match [handler name]-in-0


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to change the behavior of some part of the file register. 
#### List of Changes
<!--- Describe your changes in detail -->
- now the file register saves the `container` field in his collection
- the `container` field is propagated to the file report through the projection queue (`breaking` change on the property name and content)
- custom logic on DECRYPTED event to retrieve the pgp container
- update actions for node deprecation

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
  - [X] Unit
  - [x] Integration (Narrow)
- Post-Deploy Test
  - [ ] Isolated Microservice
  - [ ] Broader Integration
  - [x] Acceptance
  - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [X] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
